### PR TITLE
Fix icon notations: アイコンを繰り返す記法に対応

### DIFF
--- a/islands-lib/bracketing.ts
+++ b/islands-lib/bracketing.ts
@@ -19,6 +19,18 @@ export const getGyazoThumbnailUrl = (bracketingText: string): string => {
   return `https://gyazo.com/${gyazoId}/max_size/1000`;
 };
 
+export const parseIconTitle = (text) => {
+  if (text.endsWith(".icon")) {
+    return [true, text.slice(0, -5), 1];
+  }
+  const iconTowerPattern = /\.icon\*\d+$/;
+  if (iconTowerPattern.test(text)) {
+    const iconSize = text.match(/\.icon\*(\d+)$/)[1];
+    return [true, text.replace(iconTowerPattern, ""), +iconSize];
+  }
+  return [false, "", 0];
+};
+
 export const parseLinkLikeBracketing = (bracketingText: string) => {
   const text = bracketingText.replace(/[\[\]]/g, "");
   if (text.startsWith("/")) {

--- a/islands-lib/types.ts
+++ b/islands-lib/types.ts
@@ -28,6 +28,7 @@ export type LineScrapboxPageLinkProps = {
   projectName: string;
   title: string;
   isIcon: boolean;
+  iconSize: number;
   previewAreaId: string;
 };
 

--- a/islands/HTextDoc.tsx
+++ b/islands/HTextDoc.tsx
@@ -435,7 +435,6 @@ export const Line = ({
           const [isIcon, iconTitle, iconSize] = parseIconTitle(
             linkLikeRes.title
           );
-          // const isIcon = linkLikeRes.title.endsWith(".icon");
           const pageTitle = isIcon ? iconTitle : linkLikeRes.title;
           // Scrapbox bracketing
           if (!isIcon) {

--- a/islands/HTextDoc.tsx
+++ b/islands/HTextDoc.tsx
@@ -7,6 +7,7 @@ import {
   isGyazoBraketing,
   getGyazoThumbnailUrl,
   parseLinkLikeBracketing,
+  parseIconTitle,
 } from "@islands-lib/bracketing.ts";
 import { extractDecorationBold } from "../islands-lib/deco.ts";
 import {
@@ -46,21 +47,28 @@ const ScrapboxLineContent = ({
 const LineScrapboxPageIcon = ({
   projectName,
   title,
+  iconSize,
 }: {
   projectName: string;
   title: string;
+  iconSize: number;
 }) => {
   const [error, setError] = useState(false);
   const encodeTitle = encodeURIComponent(title);
   const iconUrl = `https://scrapbox.io/api/pages/${projectName}/${encodeTitle}/icon`;
   const iconNotationElems = [];
-  for (const [idx, char] of `[${encodeTitle}.icon]`.split("").entries()) {
+  const iconNotation =
+    iconSize > 0
+      ? `[${encodeTitle}.icon*${iconSize}]`
+      : `[${encodeTitle}.icon]`;
+  for (const [idx, char] of iconNotation.split("").entries()) {
     iconNotationElems.push(
       <span key={idx} class="icon-notation-char">
         {char}
       </span>
     );
   }
+  // TODO
   return (
     <Fragment>
       <span class="image-notation icon-notation">{iconNotationElems}</span>
@@ -85,6 +93,7 @@ const LineScrapboxPageLink = ({
   projectName,
   title,
   isIcon,
+  iconSize,
   previewAreaId,
 }: LineScrapboxPageLinkProps) => {
   if (!projectName || !title) {
@@ -92,7 +101,13 @@ const LineScrapboxPageLink = ({
   }
 
   if (isIcon) {
-    return <LineScrapboxPageIcon projectName={projectName} title={title} />;
+    return (
+      <LineScrapboxPageIcon
+        projectName={projectName}
+        title={title}
+        iconSize={iconSize}
+      />
+    );
   }
 
   const encodedTitle = encodeURIComponent(title);
@@ -409,10 +424,11 @@ export const Line = ({
         continue;
       } else {
         if (projectName && linkLikeRes.title) {
-          const isIcon = linkLikeRes.title.endsWith(".icon");
-          const pageTitle = isIcon
-            ? linkLikeRes.title.slice(0, -5)
-            : linkLikeRes.title;
+          const [isIcon, iconTitle, iconSize] = parseIconTitle(
+            linkLikeRes.title
+          );
+          // const isIcon = linkLikeRes.title.endsWith(".icon");
+          const pageTitle = isIcon ? iconTitle : linkLikeRes.title;
           // Scrapbox bracketing
           if (!isIcon) {
             charElems.push(
@@ -424,6 +440,7 @@ export const Line = ({
               projectName={projectName}
               title={pageTitle}
               isIcon={isIcon}
+              iconSize={iconSize}
               key={idx + "_" + linkLikeRes.title}
               previewAreaId={previewAreaId}
             />

--- a/islands/HTextDoc.tsx
+++ b/islands/HTextDoc.tsx
@@ -58,7 +58,7 @@ const LineScrapboxPageIcon = ({
   const iconUrl = `https://scrapbox.io/api/pages/${projectName}/${encodeTitle}/icon`;
   const iconNotationElems = [];
   const iconNotation =
-    iconSize > 0
+    iconSize > 1
       ? `[${encodeTitle}.icon*${iconSize}]`
       : `[${encodeTitle}.icon]`;
   for (const [idx, char] of iconNotation.split("").entries()) {
@@ -68,19 +68,27 @@ const LineScrapboxPageIcon = ({
       </span>
     );
   }
-  // TODO
+
+  const iconImgElems = [];
+  for (let i = 0; i < Math.min(iconSize, 10); i++) {
+    iconImgElems.push(
+      <img
+        key={`icon_${title}_${i}`}
+        src={iconUrl}
+        class="doc-scrapbox-icon"
+        onError={() => {
+          setError(true);
+        }}
+      />
+    );
+  }
+
   return (
     <Fragment>
       <span class="image-notation icon-notation">{iconNotationElems}</span>
       <span class="doc-icon-container">
         {!error ? (
-          <img
-            src={iconUrl}
-            class="doc-scrapbox-icon"
-            onError={() => {
-              setError(true);
-            }}
-          />
+          iconImgElems
         ) : (
           <span class="doc-scrapbox-icon-label">({encodeTitle})</span>
         )}


### PR DESCRIPTION
できた。

![](https://gyazo.com/2d0f30c4f3fdff83cfec5d159f39a750/thumb/250)

ちゃんと `[daiiz.icon*3]` のようにコピーできる。