### PR TITLE
Fix Gyazo images: /rawの扱いを修正

### DIFF
--- a/islands-lib/bracketing.ts
+++ b/islands-lib/bracketing.ts
@@ -50,7 +50,7 @@ export const parseLinkLikeBracketing = (bracketingText: string) => {
       if (isImageUrl(tok)) {
         imageUrl = tok;
       } else if (isGyazoUrl(tok)) {
-        imageUrl = tok;
+        imageUrl = tok.replace(/\/raw$/, "");
         thumbnailUrl = getGyazoThumbnailUrl(`[${tok}]`);
       } else {
         url = tok;


### PR DESCRIPTION
/rawのGyazo URLの遷移先をGyazo個別画像ページにする